### PR TITLE
Changed "Additional Options" tab into "Additional Settings"

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1318,7 +1318,7 @@ class AdminForm implements AdminFormInterface {
     $this->form['additional_options'] = [
       '#type' => 'details',
       '#group' => 'webform_civicrm',
-      '#title' => t('Additional Options'),
+      '#title' => t('Additional Settings'),
       '#attributes' => ['class' => ['civi-icon-prefs']],
     ];
     $this->form['additional_options']['checksum_text'] = [


### PR DESCRIPTION
Overview
----------------------------------------
In the webform CiviCRM settings form, the tab named "Additional Options" was renamed to "Additional Settings" as required to resolve an issue in the Webform CiviCRM issue queue assigned to me.

Before
----------------------------------------
The bottom most tab in the CiviCRM settings form that allows admin users to access additional settings for the webform is named "Additional Options".
![image](https://user-images.githubusercontent.com/60020431/125170590-e767f700-e16c-11eb-8695-dc5da49334bc.png)


After
----------------------------------------
The bottom most tab in the CiviCRM settings form has now been renamed to "Additional Settings" to make it more clear to the admin user what features that tab provides.
<img width="1036" alt="Screen Shot 2021-07-10 at 10 53 56 AM" src="https://user-images.githubusercontent.com/60020431/125170647-21d19400-e16d-11eb-83fc-c91de702a89f.png">


Technical Details
----------------------------------------
This fix involved a simple label change in the AdminForm.php file in the source folder for this project. Where the title of the bottom most tab was renamed from "Additional Options" to "Additional Settings".

Comments
----------------------------------------
